### PR TITLE
Minor changes to support deployment on TERRA-REF kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ ENV CLOWDER_URL https://terraref.ncsa.illinois.edu/clowder
 ENV SERVICE_PORT 8080
 ENV SERVICE_HOST 0.0.0.0
 
-PORTS 8080
+EXPOSE 8080
 
 CMD flask run -h ${SERVICE_HOST} -p ${SERVICE_PORT}

--- a/plot_service/api.py
+++ b/plot_service/api.py
@@ -21,7 +21,7 @@ import geojson
 from shapely import geometry
 from shapely.wkt import loads
 
-TERRAREF_BASE = '/projects/arpae/terraref/sites'
+TERRAREF_BASE = os.environ.get('TERRAREF_BASE','/projects/arpae/terraref/sites')
 Sensors = Sensors_module(TERRAREF_BASE, 'ua-mac') # a Sensors instance with a dummy site
 
 ####################################################################


### PR DESCRIPTION
* The image wouldn't build with the PORTS directive,  changed to EXPOSE
* There are two places where the TERRAREF_BASE path is hardcoded. Changed one to read from environment.  The other, in views.py, also has a hardcoded IP that doesn't appear to be responding.